### PR TITLE
Resolves IDENT-3049) Separate aries profile id from wallet.id

### DIFF
--- a/aries_cloudagent/askar/profile.py
+++ b/aries_cloudagent/askar/profile.py
@@ -54,10 +54,6 @@ class AskarProfile(Profile):
         """Accessor for the opened Store instance."""
         return self.opened.store
 
-    def opened(self) -> AskarOpenStore:
-        """Accessor for the askar open store instance."""
-        return self.opened
-
     async def remove(self):
         """Remove the profile."""
         if self.settings.get("multitenant.wallet_type") == "askar-profile":

--- a/aries_cloudagent/askar/profile.py
+++ b/aries_cloudagent/askar/profile.py
@@ -163,11 +163,11 @@ class AskarProfileSession(ProfileSession):
     ):
         """Create a new IndySdkProfileSession instance."""
         super().__init__(profile=profile, context=context, settings=settings)
-        profile_wallet_id = profile.context.settings.get("wallet.id")
+        profile_id = profile.context.settings.get("wallet.askar_profile")
         if is_txn:
-            self._opener = self.profile.store.transaction(profile_wallet_id)
+            self._opener = self.profile.store.transaction(profile_id)
         else:
-            self._opener = self.profile.store.session(profile_wallet_id)
+            self._opener = self.profile.store.session(profile_id)
         self._handle: Session = None
         self._acquire_start: float = None
         self._acquire_end: float = None

--- a/aries_cloudagent/askar/tests/test_profile.py
+++ b/aries_cloudagent/askar/tests/test_profile.py
@@ -53,30 +53,36 @@ class TestProfile(AsyncTestCase):
 
     @pytest.mark.asyncio
     async def test_profile_manager_transaction(self):
+        profile = "profileId"
 
         with mock.patch("aries_cloudagent.askar.profile.AskarProfile") as AskarProfile:
             askar_profile = AskarProfile(None, True)
             askar_profile_transaction = mock.MagicMock()
             askar_profile.store.transaction.return_value = askar_profile_transaction
-            askar_profile.context.settings.get.return_value = "walletId"
+            askar_profile.context.settings.get.return_value = profile
 
             transactionProfile = test_module.AskarProfileSession(askar_profile, True)
 
             assert transactionProfile._opener == askar_profile_transaction
-            askar_profile.context.settings.get.assert_called_once_with("wallet.id")
-            askar_profile.store.transaction.assert_called_once_with("walletId")
+            askar_profile.context.settings.get.assert_called_once_with(
+                "wallet.askar_profile"
+            )
+            askar_profile.store.transaction.assert_called_once_with(profile)
 
     @pytest.mark.asyncio
     async def test_profile_manager_store(self):
+        profile = "profileId"
 
         with mock.patch("aries_cloudagent.askar.profile.AskarProfile") as AskarProfile:
             askar_profile = AskarProfile(None, False)
             askar_profile_session = mock.MagicMock()
             askar_profile.store.session.return_value = askar_profile_session
-            askar_profile.context.settings.get.return_value = "walletId"
+            askar_profile.context.settings.get.return_value = profile
 
             sessionProfile = test_module.AskarProfileSession(askar_profile, False)
 
             assert sessionProfile._opener == askar_profile_session
-            askar_profile.context.settings.get.assert_called_once_with("wallet.id")
-            askar_profile.store.session.assert_called_once_with("walletId")
+            askar_profile.context.settings.get.assert_called_once_with(
+                "wallet.askar_profile"
+            )
+            askar_profile.store.session.assert_called_once_with(profile)

--- a/aries_cloudagent/multitenant/askar_profile_manager.py
+++ b/aries_cloudagent/multitenant/askar_profile_manager.py
@@ -73,9 +73,10 @@ class AskarProfileMultitenantManager(BaseMultitenantManager):
         if provision:
             await multitenant_wallet.store.create_profile(wallet_record.wallet_id)
 
-        extra_settings["admin.webhook_urls"] = self.get_webhook_urls(
-            base_context, wallet_record
-        )
+        extra_settings = {
+            "admin.webhook_urls": self.get_webhook_urls(base_context, wallet_record),
+            "wallet.askar_profile": wallet_record.wallet_id,
+        }
 
         profile_context.settings = profile_context.settings.extend(
             wallet_record.settings

--- a/aries_cloudagent/multitenant/tests/test_askar_profile_manager.py
+++ b/aries_cloudagent/multitenant/tests/test_askar_profile_manager.py
@@ -104,10 +104,17 @@ class TestAskarProfileMultitenantManager(AsyncTestCase):
                 assert (
                     sub_wallet_profile_context.settings.get("mediation.clear") == True
                 )
-                assert sub_wallet_profile_context.settings.get("wallet.id") == "test"
+                assert (
+                    sub_wallet_profile_context.settings.get("wallet.id")
+                    == wallet_record.wallet_id
+                )
                 assert (
                     sub_wallet_profile_context.settings.get("wallet.name")
                     == "test_name"
+                )
+                assert (
+                    sub_wallet_profile_context.settings.get("wallet.askar_profile")
+                    == wallet_record.wallet_id
                 )
 
     async def test_get_wallet_profile_should_create_profile(self):

--- a/aries_cloudagent/storage/askar.py
+++ b/aries_cloudagent/storage/askar.py
@@ -367,7 +367,7 @@ class AskarStorageSearchSession(BaseStorageSearchSession):
             self._scan = self._profile.store.scan(
                 self.type_filter,
                 self.tag_query,
-                profile=self._profile.settings.get("wallet.id"),
+                profile=self._profile.settings.get("wallet.askar_profile"),
             )
         except AskarError as err:
             raise StorageSearchError("Error opening search query") from err

--- a/aries_cloudagent/storage/tests/test_askar_storage.py
+++ b/aries_cloudagent/storage/tests/test_askar_storage.py
@@ -356,6 +356,7 @@ class TestAskarStorage(test_in_memory_storage.TestInMemoryStorage):
 class TestAskarStorageSearchSession(AsyncTestCase):
     @pytest.mark.asyncio
     async def test_askar_storage_search_session(self):
+        profile = "profileId"
 
         with async_mock.patch(
             "aries_cloudagent.storage.askar.AskarProfile"
@@ -363,7 +364,7 @@ class TestAskarStorageSearchSession(AsyncTestCase):
             askar_profile = AskarProfile(None, True)
             askar_profile_scan = async_mock.MagicMock()
             askar_profile.store.scan.return_value = askar_profile_scan
-            askar_profile.settings.get.return_value = "walletId"
+            askar_profile.settings.get.return_value = profile
 
             storageSearchSession = test_module.AskarStorageSearchSession(
                 askar_profile, "filter", "tagQuery"
@@ -371,7 +372,7 @@ class TestAskarStorageSearchSession(AsyncTestCase):
             await storageSearchSession._open()
 
             assert storageSearchSession._scan == askar_profile_scan
-            askar_profile.settings.get.assert_called_once_with("wallet.id")
+            askar_profile.settings.get.assert_called_once_with("wallet.askar_profile")
             askar_profile.store.scan.assert_called_once_with(
-                "filter", "tagQuery", profile="walletId"
+                "filter", "tagQuery", profile=profile
             )


### PR DESCRIPTION
## What is this MR for?

- Separate profile id from wallet id to avoid clash between multitenant managers