### PR TITLE
Pack outbound messages before pushing them to the queue

### DIFF
--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -532,8 +532,9 @@ class Conductor:
                 [outbound.target] if outbound.target else (outbound.target_list or [])
             )
             for target in targets:
+                encoded_outbound_message = await self.outbound_transport_manager.encode_message_external_queue(profile, outbound, target)
                 await self.outbound_queue.enqueue_message(
-                    outbound.payload, target.endpoint
+                    encoded_outbound_message.payload, target.endpoint
                 )
 
             return OutboundSendStatus.SENT_TO_EXTERNAL_QUEUE

--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -532,7 +532,11 @@ class Conductor:
                 [outbound.target] if outbound.target else (outbound.target_list or [])
             )
             for target in targets:
-                encoded_outbound_message = await self.outbound_transport_manager.encode_message_external_queue(profile, outbound, target)
+                encoded_outbound_message = (
+                    await self.outbound_transport_manager.encode_outbound_message(
+                        profile, outbound, target
+                    )
+                )
                 await self.outbound_queue.enqueue_message(
                     encoded_outbound_message.payload, target.endpoint
                 )

--- a/aries_cloudagent/transport/outbound/manager.py
+++ b/aries_cloudagent/transport/outbound/manager.py
@@ -264,7 +264,7 @@ class OutboundTransportManager:
         self, profile: Profile, outbound: OutboundMessage, target: ConnectionTarget
     ):
         """
-        Encodes outbound messages.
+        Encode outbound message for the target.
 
         Args:
             profile: The active profile for the request

--- a/aries_cloudagent/transport/outbound/manager.py
+++ b/aries_cloudagent/transport/outbound/manager.py
@@ -260,6 +260,24 @@ class OutboundTransportManager:
         self.outbound_new.append(queued)
         self.process_queued()
 
+    async def encode_message_external_queue(self, profile: Profile, outbound: OutboundMessage, target: ConnectionTarget):
+        """
+        Encodes outbound message for the external queue.
+        Args:
+            profile: The active profile for the request
+            outbound: The outbound message to deliver
+            target: The outbound message target
+        """
+
+        outbound_message = QueuedOutboundMessage(profile, outbound, target, None)
+
+        if outbound_message.message and outbound_message.message.enc_payload:
+            outbound_message.payload = outbound_message.message.enc_payload
+        else:
+            await self.perform_encode(outbound_message, None)
+
+        return outbound_message
+
     def enqueue_webhook(
         self,
         topic: str,
@@ -415,16 +433,17 @@ class OutboundTransportManager:
 
     def encode_queued_message(self, queued: QueuedOutboundMessage) -> asyncio.Task:
         """Kick off encoding of a queued message."""
+        transport = self.get_transport_instance(queued.transport_id)
+
         queued.task = self.task_queue.run(
-            self.perform_encode(queued),
+            self.perform_encode(queued, transport.wire_format),
             lambda completed: self.finished_encode(queued, completed),
         )
         return queued.task
 
-    async def perform_encode(self, queued: QueuedOutboundMessage):
+    async def perform_encode(self, queued: QueuedOutboundMessage, wire_format: BaseWireFormat):
         """Perform message encoding."""
-        transport = self.get_transport_instance(queued.transport_id)
-        wire_format = transport.wire_format or self.context.inject(BaseWireFormat)
+        wire_format = wire_format or self.context.inject(BaseWireFormat)
         session = await queued.profile.session()
         queued.payload = await wire_format.encode_message(
             session,

--- a/aries_cloudagent/transport/outbound/manager.py
+++ b/aries_cloudagent/transport/outbound/manager.py
@@ -264,7 +264,8 @@ class OutboundTransportManager:
         self, profile: Profile, outbound: OutboundMessage, target: ConnectionTarget
     ):
         """
-        Encodes outbound message for the external queue.
+        Encodes outbound messages.
+
         Args:
             profile: The active profile for the request
             outbound: The outbound message to deliver


### PR DESCRIPTION
## What is this MR for?

- When using external queue outbound messages are currently not packed.
-  This MR packs messages for the recipient before pushing them to the external queue.