### PR TITLE
Feature: Add acapy-cache-redis plugin

### DIFF
--- a/docker/Dockerfile.globalid
+++ b/docker/Dockerfile.globalid
@@ -2,6 +2,7 @@ FROM python:3.10-slim
 ENV ENABLE_PTVSD 0
 
 RUN apt-get update && apt-get upgrade -y
+RUN apt-get install git -y
 
 WORKDIR cloudagent
 ADD aries_cloudagent ./aries_cloudagent

--- a/requirements.globalid.txt
+++ b/requirements.globalid.txt
@@ -2,3 +2,4 @@ ddtrace~=0.57.1
 datadog~=0.43.0
 boto3[crt]~=1.20.40
 cryptography~=36.0.1
+git+https://github.com/Indicio-tech/acapy-cache-redis.git@main#egg=acapy_cache_redis


### PR DESCRIPTION
This adds the `acapy-cache-redis` plugin to the Dockerfile. Additional configuration will need to be provided to the plugin via the following config options. In addition to having the plugin in the container and adding it to the list of external plugins, the plugin will need ACA-Py 0.7.4 (specifically this PR https://github.com/hyperledger/aries-cloudagent-python/pull/1774) in order to run.
```
plugin-config-value: 'redis_cache.connection="redis//redis-server:6379/"'

# Optional
plugin-config-value: 'redis_cache.credentials.username="redis-user"'
plugin-config-value: 'redis_cache.credentials.password="password"'
```