### PR TITLE
IDCORE-4594: add wallet.source parameter to POST and PUT requests

### DIFF
--- a/aries_cloudagent/multitenant/admin/routes.py
+++ b/aries_cloudagent/multitenant/admin/routes.py
@@ -98,6 +98,12 @@ class CreateWalletRequestSchema(OpenAPISchema):
         example="https://aries.ca/images/sample.png",
     )
 
+    wallet_source = fields.Str(
+        description="Wallet source. Arbitrary value describing the wallet creation source",
+        example="MyNewWalletSource",
+        required=False,
+    )
+
     key_management_mode = fields.Str(
         description="Key management method to use for this wallet.",
         example=WalletRecord.MODE_MANAGED,
@@ -154,6 +160,12 @@ class UpdateWalletRequestSchema(OpenAPISchema):
         description="Image url for this wallet. This image url is publicized\
             (self-attested) to other agents as part of forming a connection.",
         example="https://aries.ca/images/sample.png",
+    )
+
+    wallet_source = fields.Str(
+        description="Wallet source. Arbitrary value describing the wallet creation source",
+        example="MyNewWalletSource",
+        required=False,
     )
 
 
@@ -303,10 +315,13 @@ async def wallet_create(request: web.BaseRequest):
 
     label = body.get("label")
     image_url = body.get("image_url")
+    wallet_source = body.get("wallet_source")
     if label:
         settings["default_label"] = label
     if image_url:
         settings["image_url"] = image_url
+    if wallet_source:
+        settings["wallet.source"] = wallet_source
 
     try:
         multitenant_mgr = context.profile.inject(BaseMultitenantManager)
@@ -346,6 +361,7 @@ async def wallet_update(request: web.BaseRequest):
     wallet_dispatch_type = body.get("wallet_dispatch_type")
     label = body.get("label")
     image_url = body.get("image_url")
+    wallet_source = body.get("wallet_source")
 
     if all(
         v is None for v in (wallet_webhook_urls, wallet_dispatch_type, label, image_url)
@@ -368,6 +384,8 @@ async def wallet_update(request: web.BaseRequest):
         settings["default_label"] = label
     if image_url is not None:
         settings["image_url"] = image_url
+    if wallet_source is not None:
+        settings["wallet.source"] = wallet_source
 
     try:
         multitenant_mgr = context.profile.inject(BaseMultitenantManager)

--- a/aries_cloudagent/multitenant/admin/routes.py
+++ b/aries_cloudagent/multitenant/admin/routes.py
@@ -100,7 +100,7 @@ class CreateWalletRequestSchema(OpenAPISchema):
 
     wallet_source = fields.Str(
         description="Wallet source. Arbitrary value describing the wallet creation source",
-        example="MyNewWalletSource",
+        example="MyWalletSource",
         required=False,
     )
 
@@ -164,7 +164,7 @@ class UpdateWalletRequestSchema(OpenAPISchema):
 
     wallet_source = fields.Str(
         description="Wallet source. Arbitrary value describing the wallet creation source",
-        example="MyNewWalletSource",
+        example="MyWalletSource",
         required=False,
     )
 
@@ -364,7 +364,7 @@ async def wallet_update(request: web.BaseRequest):
     wallet_source = body.get("wallet_source")
 
     if all(
-        v is None for v in (wallet_webhook_urls, wallet_dispatch_type, label, image_url)
+        v is None for v in (wallet_webhook_urls, wallet_dispatch_type, label, image_url, wallet_source)
     ):
         raise web.HTTPBadRequest(reason="At least one parameter is required.")
 

--- a/aries_cloudagent/multitenant/admin/tests/test_routes.py
+++ b/aries_cloudagent/multitenant/admin/tests/test_routes.py
@@ -208,7 +208,7 @@ class TestMultitenantRoutes(AsyncTestCase):
         body = {
             "wallet_name": "test",
             "wallet_key": "test",
-            "wallet_source": "",
+            "wallet_source": None,
             "wallet_webhook_urls": [],
             "wallet_dispatch_type": "base",
             "label": "my_test_label",

--- a/aries_cloudagent/multitenant/admin/tests/test_routes.py
+++ b/aries_cloudagent/multitenant/admin/tests/test_routes.py
@@ -144,6 +144,7 @@ class TestMultitenantRoutes(AsyncTestCase):
             "wallet_name": "test",
             "wallet_type": "indy",
             "wallet_key": "test",
+            "wallet_source": "source",
             "key_management_mode": "managed",
             "wallet_webhook_urls": [],
             "wallet_dispatch_type": "base",
@@ -177,6 +178,7 @@ class TestMultitenantRoutes(AsyncTestCase):
                     "wallet.key": body["wallet_key"],
                     "wallet.webhook_urls": body["wallet_webhook_urls"],
                     "wallet.dispatch_type": body["wallet_dispatch_type"],
+                    "wallet.source": body["wallet_source"],
                 },
                 body["key_management_mode"],
             )
@@ -206,6 +208,7 @@ class TestMultitenantRoutes(AsyncTestCase):
         body = {
             "wallet_name": "test",
             "wallet_key": "test",
+            "wallet_source": "",
             "wallet_webhook_urls": [],
             "wallet_dispatch_type": "base",
             "label": "my_test_label",
@@ -236,6 +239,7 @@ class TestMultitenantRoutes(AsyncTestCase):
         body = {
             "wallet_webhook_urls": ["test-webhook-url"],
             "wallet_dispatch_type": "default",
+            "wallet_source": "newSource",
             "label": "test-label",
             "image_url": "test-image-url",
         }
@@ -245,6 +249,7 @@ class TestMultitenantRoutes(AsyncTestCase):
             settings = {
                 "wallet.webhook_urls": body["wallet_webhook_urls"],
                 "wallet.dispatch_type": body["wallet_dispatch_type"],
+                "wallet.source": body["wallet_source"],
                 "default_label": body["label"],
                 "image_url": body["image_url"],
             }

--- a/aries_cloudagent/storage/askar.py
+++ b/aries_cloudagent/storage/askar.py
@@ -92,7 +92,9 @@ class AskarStorage(BaseStorage):
         except AskarError as err:
             raise StorageError("Error when fetching storage record") from err
         if not item:
-            raise StorageNotFoundError(f"Record not found: {record_type}/{record_id}")
+            raise StorageNotFoundError(
+                f"Record not found: {record_type}/{record_id}/{self._session.profile.settings.get('wallet.id')}"
+            )
         return StorageRecord(
             type=item.category,
             id=item.name,

--- a/aries_cloudagent/storage/askar.py
+++ b/aries_cloudagent/storage/askar.py
@@ -92,9 +92,7 @@ class AskarStorage(BaseStorage):
         except AskarError as err:
             raise StorageError("Error when fetching storage record") from err
         if not item:
-            raise StorageNotFoundError(
-                f"Record not found: {record_type}/{record_id}/{self._session.profile.settings.get('wallet.id')}"
-            )
+            raise StorageNotFoundError(f"Record not found: {record_type}/{record_id}")
         return StorageRecord(
             type=item.category,
             id=item.name,


### PR DESCRIPTION
Accept wallet source as a parameter and propagate it to wallet settings
dict.

Signed-off-by: Gasper Vrhovsek <gasper.vrhovsek@gmail.com>