### PR TITLE
build: replace requirement pika with aio-pika

### DIFF
--- a/requirements.globalid.txt
+++ b/requirements.globalid.txt
@@ -2,4 +2,4 @@ ddtrace==1.2.2
 datadog==0.44.0
 boto3[crt]==1.24.30
 cryptography==37.0.4
-pika~=1.2.1
+aio-pika~=8.1.0


### PR DESCRIPTION
aio-pika uses asyncio which is used within acapy and makes it easier to work with async tasks